### PR TITLE
fix linking in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC := gcc
 XFLAGS := -Wall -std=c11 -D_POSIX_C_SOURCE=199309L
 LIBRARIES := -levdev
 INCLUDES := -I/usr/include/libevdev-1.0
-CFLAGS := $(XFLAGS) $(LIBRARIES) $(INCLUDES)
+CFLAGS := $(XFLAGS) $(INCLUDES)
 
 OUTDIR := out
 SOURCES := uinput.c input.c rce.c
@@ -16,7 +16,7 @@ $(OUTDIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $^ $(LIBRARIES) -o $@
 
 all: $(TARGET)
 clean:


### PR DESCRIPTION
gcc parameter -l* must be placed after object files that refer to the libraries' symbols

Fixes #2
Fixes #15