### PR TITLE
fixes build on devuan chimaera and older systems i guess.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(OUTDIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(XFLAGS) $^ $(LIBRARIES) -o $@
 
 all: $(TARGET)
 clean:


### PR DESCRIPTION
with older linkers it is necessary that the -levdev flag be after the object files that require it, otherwise linker doesn't find the libraries and symbols.

i was having:

```
gcc -Wall -std=c11 -D_POSIX_C_SOURCE=199309L -I/usr/include/libevdev-1.0 -levdev out/uinput.o out/input.o out/rce.o -o out/evdev-rce
/usr/bin/ld: out/uinput.o: in function `uinput_initialize':
uinput.c:(.text+0x6): undefined reference to `libevdev_new'
/usr/bin/ld: uinput.c:(.text+0x14): undefined reference to `libevdev_set_name'
/usr/bin/ld: uinput.c:(.text+0x1c): undefined reference to `libevdev_enable_event_type'
/usr/bin/ld: uinput.c:(.text+0x2a): undefined reference to `libevdev_enable_event_code'
/usr/bin/ld: uinput.c:(.text+0x3c): undefined reference to `libevdev_uinput_create_from_device'
/usr/bin/ld: uinput.c:(.text+0x4c): undefined reference to `libevdev_free'
/usr/bin/ld: out/uinput.o: in function `uinput_send_right_click':
uinput.c:(.text+0x72): undefined reference to `libevdev_uinput_write_event'
/usr/bin/ld: uinput.c:(.text+0x7e): undefined reference to `libevdev_uinput_write_event'
/usr/bin/ld: uinput.c:(.text+0x8c): undefined reference to `libevdev_uinput_write_event'
/usr/bin/ld: uinput.c:(.text+0x98): undefined reference to `libevdev_uinput_write_event'
/usr/bin/ld: out/input.o: in function `free_evdev':
input.c:(.text+0xa): undefined reference to `libevdev_get_fd'
/usr/bin/ld: input.c:(.text+0x12): undefined reference to `libevdev_free'
/usr/bin/ld: out/input.o: in function `build_fd_set':
input.c:(.text+0xa4): undefined reference to `libevdev_get_fd'
/usr/bin/ld: out/input.o: in function `process_evdev_input':
input.c:(.text+0x384): undefined reference to `libevdev_get_fd'
/usr/bin/ld: input.c:(.text+0x3b2): undefined reference to `libevdev_get_fd'
/usr/bin/ld: input.c:(.text+0x3fa): undefined reference to `libevdev_next_event'
/usr/bin/ld: input.c:(.text+0x45c): undefined reference to `libevdev_uinput_destroy'
/usr/bin/ld: out/rce.o: in function `find_evdev':
rce.c:(.text+0x11c): undefined reference to `libevdev_new_from_fd'
/usr/bin/ld: rce.c:(.text+0x150): undefined reference to `libevdev_has_event_type'
/usr/bin/ld: rce.c:(.text+0x160): undefined reference to `libevdev_has_event_type'
/usr/bin/ld: rce.c:(.text+0x174): undefined reference to `libevdev_has_event_code'
/usr/bin/ld: rce.c:(.text+0x188): undefined reference to `libevdev_has_event_code'
/usr/bin/ld: rce.c:(.text+0x196): undefined reference to `libevdev_get_name'
/usr/bin/ld: rce.c:(.text+0x22a): undefined reference to `libevdev_free'
collect2: error: ld returned 1 exit status
make: *** [Makefile:19: out/evdev-rce] Error 1
```

unless i made the change in this pull request.